### PR TITLE
Stepper: Fixed typo in argument name (in docblock).

### DIFF
--- a/src/Components/Stepper/Stepper.php
+++ b/src/Components/Stepper/Stepper.php
@@ -14,7 +14,7 @@ use MoonShine\UI\Components\ActionButton;
 use Throwable;
 
 /**
- * @method static static make(iterable $components = [], iterable $finishComponents = [], string $nextText = 'Next', string $finishText = 'Finish')
+ * @method static static make(iterable $components = [], iterable $finishComponent = [], string $nextText = 'Next', string $finishText = 'Finish')
  */
 final class Stepper extends AbstractWithComponents
 {


### PR DESCRIPTION
This typo causes the IDE to complain when using named arguments.